### PR TITLE
Update the build script to work with 0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.bak
 /.idea/
 /tmp/
 /poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,7 @@ importlib_resources =        ">=1.4"
 
 [tool.poetry.dependencies.ics]
 optional = true
-# extra = update
-# A) via PyPi
-version = "^0.8.0"
-# B) via GitHub
-#git = "https://github.com/C4ptainCrunch/ics.py.git"
-#branch = "timezones"
-# C) via local filesystem
-#path = "../ics.py"
+version = "^0.8.0.dev0"
 
 [tool.poetry.extras]
 update = ["ics"]

--- a/update.sh
+++ b/update.sh
@@ -16,7 +16,7 @@ mkdir -p ./tmp/cldr
 tmp_vzic=$(realpath ./tmp/vzic)
 tmp_cldr=$(realpath ./tmp/cldr)
 
-sed -i 's#^version\s*=.*$#version = "'$1'"#' pyproject.toml
+sed -i .bak 's#^version\s*=.*$#version = "'$1'"#' pyproject.toml
 
 pushd "src/ics_vtimezones"
 echo -e 'VERSION = "'$1'"\nBUILTIN_TZID_PREFIX = "/ics.py/"\nTZID_PREFIX = "/ics.py/'$1'/"' > "__config__.py"
@@ -38,13 +38,13 @@ rm -rf ./tzdata*
 curl -R ftp://ftp.iana.org/tz/tzdata-latest.tar.gz -o tzdata-latest.tar.gz
 mkdir tzdata
 pushd tzdata
-tar -xaf ../tzdata-latest.tar.gz
+tar -xf ../tzdata-latest.tar.gz
 popd
-sed -i 's#^OLSON_DIR\s*=.*$#OLSON_DIR = tzdata#' Makefile
-sed -i 's#^PRODUCT_ID\s*=.*$#PRODUCT_ID = ics.py - http://git.io/lLljaA - vTimezone.ics#' Makefile
-sed -i 's#^TZID_PREFIX\s*=.*$#TZID_PREFIX = /ics.py/'$1'/#' Makefile
+sed -i .bak 's#^OLSON_DIR\s*=.*$#OLSON_DIR = tzdata#' Makefile
+sed -i .bak 's#^PRODUCT_ID\s*=.*$#PRODUCT_ID = ics.py - http://git.io/lLljaA - vTimezone.ics#' Makefile
+sed -i .bak 's#^TZID_PREFIX\s*=.*$#TZID_PREFIX = /ics.py/'$1'/#' Makefile
 make -B
-./vzic
+./vzic --olson-dir tzdata
 python3 "$update_zoneinfo" "$tmp_vzic/zoneinfo" "$zoneinfo_dir" --index="$zoneinfo_index"
 popd
 

--- a/update.sh
+++ b/update.sh
@@ -40,10 +40,7 @@ mkdir tzdata
 pushd tzdata
 tar -xf ../tzdata-latest.tar.gz
 popd
-sed -i .bak 's#^OLSON_DIR\s*=.*$#OLSON_DIR = tzdata#' Makefile
-sed -i .bak 's#^PRODUCT_ID\s*=.*$#PRODUCT_ID = ics.py - http://git.io/lLljaA - vTimezone.ics#' Makefile
-sed -i .bak 's#^TZID_PREFIX\s*=.*$#TZID_PREFIX = /ics.py/'$1'/#' Makefile
-make -B
+make -B PRODUCT_ID="ics.py - http://git.io/lLljaA - iCal vTZ" TZID_PREFIX=/ics.py/$1/
 ./vzic --olson-dir tzdata
 python3 "$update_zoneinfo" "$tmp_vzic/zoneinfo" "$zoneinfo_dir" --index="$zoneinfo_index"
 popd

--- a/update_zoneinfo.py
+++ b/update_zoneinfo.py
@@ -5,16 +5,16 @@ import os
 import shutil
 import sys
 
-from ics.grammar import string_to_container
+from ics.contentline import string_to_container
 from ics.timezone import Timezone
 
 
 def read_tz(path):
     with open(path, "rt") as f:
         ics_cal = string_to_container(f.read())
-        if not (len(ics_cal) == 1 and len(ics_cal[0]) == 3 and ics_cal[0][2].name == "VTIMEZONE"):
+        if not (len(ics_cal) == 3 and ics_cal[2].name == "VTIMEZONE"):
             raise ValueError("vTimezone.ics file %s has invalid content" % path)
-        return Timezone.from_container(ics_cal[0][2])
+        return Timezone.from_container(ics_cal[2])
 
 
 def list_files(dir):


### PR DESCRIPTION
Hello @N-Coder 👋 

I'm trying to update ics_vtimezones before the release of ics 0.8. Would it be possible to transfer the ownership to the ics GitHub org ? (Could you also give me write access to it on pypi ?)